### PR TITLE
Fixed broken link to photography section in the Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This repo is a collection of **AWESOME** APIs for developers. Feel free to **Sta
 + [News & Information](#news--information)
 + [Notes](#notes)
 + [Payment](#payment)
-+ [Photography](#Photography)
++ [Photography](#photography)
 + [Places](#places)
 + [Social](#social)
 + [Shopping](#shopping)


### PR DESCRIPTION
Hey guys. The photography link was broken in the Readme because of a typo. This PR fixes it. 